### PR TITLE
preventing dimming/switching of uninitialized devices and updating th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc/*
 *.iml
 .idea/*
 coverage.html
+.DS_STORE

--- a/accessories/dimmer.coffee
+++ b/accessories/dimmer.coffee
@@ -41,7 +41,8 @@ module.exports = (env) ->
             @handleVoidPromise(device.changeDimlevelTo(value), callback)
           else
             #if we don't have a dim level yet we can not properly determine whether to dim or not
-            env.logger.debug "Device #{device.name} dim level not initialized yet, ignoring dim level change"
+            env.logger.debug "Device #{device.name} dim level not initialized yet, 
+            ignoring dim level change"
             callback()
             return
 

--- a/accessories/dimmer.coffee
+++ b/accessories/dimmer.coffee
@@ -15,7 +15,6 @@ module.exports = (env) ->
 
     constructor: (device) ->
       super(device)
-      @_dimlevel = device._dimlevel
 
       @getService(Service.Lightbulb)
         .getCharacteristic(Characteristic.Brightness)
@@ -29,15 +28,22 @@ module.exports = (env) ->
       @getService(Service.Lightbulb)
         .getCharacteristic(Characteristic.Brightness)
         .on 'set', (value, callback) =>
-          if @_dimlevel is value
-            env.logger.debug 'value ' + value +
-              ' equals current dimlevel of ' + device.name  + '. Not changing.'
+          @_dimlevel = device._dimlevel
+          if @_dimlevel != null
+            if @_dimlevel is value 
+              env.logger.debug 'value ' + value +
+                ' equals current dimlevel of ' + device.name  + '. Not changing.'
+              callback()
+              return
+            env.logger.debug 'changing dimlevel of ' + device.name + ' to ' + value
+            @_dimlevel = value
+            @_state = value > 0
+            @handleVoidPromise(device.changeDimlevelTo(value), callback)
+          else
+            #if we don't have a dim level yet we can not properly determine whether to dim or not
+            env.logger.debug "Device #{device.name} dim level not initialized yet, ignoring dim level change"
             callback()
             return
-          env.logger.debug 'changing dimlevel of ' + device.name + ' to ' + value
-          @_dimlevel = value
-          @_state = value > 0
-          @handleVoidPromise(device.changeDimlevelTo(value), callback)
 
     getDefaultService: =>
       return Service.Lightbulb

--- a/accessories/switch.coffee
+++ b/accessories/switch.coffee
@@ -35,7 +35,8 @@ module.exports = (env) ->
             @handleVoidPromise(promise, callback)
           else
             #if we don't have a state yet we can not properly determine whether to switch or not
-            env.logger.debug "Device #{device.name} state not initialized yet, ignoring state change"
+            env.logger.debug "Device #{device.name} state not initialized yet, 
+            ignoring state change"
             callback()
             return
 


### PR DESCRIPTION
…e state/dimLevel when event happens and not only in the constructor

I found out that at the moment the plugin tries to determine if it should switch the state @_state was null and it was only written in the constructor at this point in time. I think it is legit to get the device state on every new set which comes in from homekit and use this for evaluation. 
In addition to that I think there can be the case that a device still was not yet able to update its internal state if a "set" comes from homekit. We should not switch a device in this state and thus I added a null check.
