### PR TITLE
Bugfix @getHueForMilight(value) - incorrect method name

### DIFF
--- a/accessories/milight.coffee
+++ b/accessories/milight.coffee
@@ -21,7 +21,7 @@ module.exports = (env) ->
       @service.getCharacteristic(Characteristic.Hue)
         .on 'set', (value, callback) =>
           # value = 0 -> hue = 176
-          hue = @getHueForMilight(value)
+          hue = @_getHueForMilight(value)
           if hue is @_hue
             callback()
             return


### PR DESCRIPTION
Method name was incorrect (missing underscode), hard crashing Pimatic.