### PR TITLE
add raspbee color-temperature device and raspbee multi sensor

### DIFF
--- a/accessories/genericsensor.coffee
+++ b/accessories/genericsensor.coffee
@@ -11,7 +11,8 @@ module.exports = (env) ->
   ##
   class GenericAccessory extends BaseAccessory
 
-    @supportedAttributes: ['temperature', 'humidity', 'co2', 'presence', 'contact', 'water', 'carbon', 'lux', 'fire']
+    @supportedAttributes: ['temperature', 'humidity', 'co2', 'presence',
+      'contact', 'water', 'carbon', 'lux', 'fire']
 
     constructor: (device) ->
       super(device)

--- a/accessories/genericsensor.coffee
+++ b/accessories/genericsensor.coffee
@@ -11,7 +11,7 @@ module.exports = (env) ->
   ##
   class GenericAccessory extends BaseAccessory
 
-    @supportedAttributes: ['temperature', 'humidity', 'co2']
+    @supportedAttributes: ['temperature', 'humidity', 'co2', 'presence', 'contact', 'water', 'carbon', 'lux', 'fire']
 
     constructor: (device) ->
       super(device)
@@ -64,6 +64,78 @@ module.exports = (env) ->
 
         @addRemoveListener(device, @getService(Service.CarbonDioxideSensor))
 
+      if device.hasAttribute('presence')
+        @addService(Service.MotionSensor, device.name)
+          .getCharacteristic(Characteristic.MotionDetected)
+          .on 'get', (callback) =>
+            @handleReturnPromise(device.getPresence(), callback, null)
+
+        device.on 'presence', (motionDetected) =>
+          @getService(Service.MotionSensor)
+            .updateCharacteristic(Characteristic.MotionDetected, motionDetected)
+
+        @addBatteryStatus(device, @getService(Service.MotionSensor))
+        @addRemoveListener(device, @getService(Service.MotionSensor))
+
+      if device.hasAttribute('contact')
+        @addService(Service.ContactSensor, device.name)
+          .getCharacteristic(Characteristic.ContactSensorState)
+          .on 'get', (callback) =>
+            @handleReturnPromise(device.getContact(), callback, @getContactSensorState)
+        device.on 'contact', (state) =>
+          @getService(Service.ContactSensor)
+            .updateCharacteristic(Characteristic.ContactSensorState, @getContactSensorState(state))
+
+        @addBatteryStatus(device, @getService(Service.ContactSensor))
+        @addRemoveListener(device, @getService(Service.ContactSensor))
+
+      if device.hasAttribute('water')
+        @addService(Service.LeakSensor, device.name)
+          .getCharacteristic(Characteristic.LeakDetected)
+          .on 'get', (callback) =>
+            @handleReturnPromise(device.getWater(), callback, @getWaterState)
+        device.on 'water', (state) =>
+          @getService(Service.LeakSensor)
+            .updateCharacteristic(Characteristic.LeakDetected, @getWaterState(state))
+
+        @addBatteryStatus(device, @getService(Service.LeakSensor))
+        @addRemoveListener(device, @getService(Service.LeakSensor))
+
+      if device.hasAttribute('carbon')
+        @addService(Service.CarbonMonoxideSensor, device.name)
+          .getCharacteristic(Characteristic.CarbonMonoxideDetected)
+          .on 'get', (callback) =>
+            @handleReturnPromise(device.getCarbon(), callback, @getCarbonState)
+        device.on 'carbon', (state) =>
+          @getService(Service.CarbonMonoxideSensor)
+            .updateCharacteristic(Characteristic.CarbonMonoxideDetected, @getCarbonState(state))
+
+        @addBatteryStatus(device, @getService(Service.CarbonMonoxideSensor))
+        @addRemoveListener(device, @getService(Service.CarbonMonoxideSensor))
+
+      if device.hasAttribute('lux')
+        @addService(Service.LightSensor, device.name)
+          .getCharacteristic(Characteristic.CurrentAmbientLightLevel)
+          .on 'get', (callback) =>
+            @handleReturnPromise(device.getLux(), callback, null)
+        device.on 'lux', (state) =>
+          @getService(Service.LightSensor)
+            .updateCharacteristic(Characteristic.CurrentAmbientLightLevel, state)
+
+        @addBatteryStatus(device, @getService(Service.LightSensor))
+        @addRemoveListener(device, @getService(Service.LightSensor))
+
+      if device.hasAttribute('fire')
+        @addService(Service.SmokeSensor, device.name)
+          .getCharacteristic(Characteristic.SmokeDetected)
+          .on 'get', (callback) =>
+            @handleReturnPromise(device.getFire(), callback, @getSmokeState)
+        device.on 'fire', (state) =>
+          @getService(Service.SmokeSensor)
+            .updateCharacteristic(Characteristic.SmokeDetected, @getSmokeState(state))
+
+        @addBatteryStatus(device, @getService(Service.SmokeSensor))
+        @addRemoveListener(device, @getService(Service.SmokeSensor))
 
     addBatteryStatus: (device, service) =>
       if device.hasAttribute('lowBattery')
@@ -75,6 +147,22 @@ module.exports = (env) ->
         device.on 'lowBattery', (state) =>
           service
             .updateCharacteristic(Characteristic.StatusLowBattery, @getBatteryStatus(state))
+      if device.hasAttribute('battery')
+        service
+          .getCharacteristic(Characteristic.StatusLowBattery)
+          .on 'get', (callback) =>
+            @handleReturnPromise(device.getBattery(), callback, @isBatteryLow)
+
+        device.on 'battery', (value) =>
+          service
+            .updateCharacteristic(Characteristic.StatusLowBattery, @isBatteryLow(value))
+
+    # lowBattery if battery value is < 20%
+    isBatteryLow: (value) =>
+      if value < 20
+        return Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
+      else
+        return Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL
 
     getBatteryStatus: (state) =>
       if state
@@ -87,6 +175,30 @@ module.exports = (env) ->
       if co2 > 1400
         return Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL
       return Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL
+
+    getContactSensorState: (state) =>
+      if state
+        return Characteristic.ContactSensorState.CONTACT_DETECTED
+      else
+        return Characteristic.ContactSensorState.CONTACT_NOT_DETECTED
+
+    getWaterState: (state) =>
+      if state
+        return Characteristic.LeakDetected.LEAK_DETECTED
+      else
+        return Characteristic.LeakDetected.LEAK_NOT_DETECTED
+
+    getCarbonState: (state) =>
+      if state
+        return Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL
+      else
+        return Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL
+
+    getSmokeState: (state) =>
+      if state
+        return Characteristic.SmokeDetected.SMOKE_DETECTED
+      else
+        return Characteristic.SmokeDetected.SMOKE_NOT_DETECTED
 
     addRemoveListener: (device, service) =>
       device.on 'remove', () =>

--- a/accessories/genericsensor.coffee
+++ b/accessories/genericsensor.coffee
@@ -148,7 +148,8 @@ module.exports = (env) ->
         device.on 'lowBattery', (state) =>
           service
             .updateCharacteristic(Characteristic.StatusLowBattery, @getBatteryStatus(state))
-      if device.hasAttribute('battery')
+
+      else if device.hasAttribute('battery')
         service
           .getCharacteristic(Characteristic.StatusLowBattery)
           .on 'get', (callback) =>

--- a/accessories/raspbeect.coffee
+++ b/accessories/raspbeect.coffee
@@ -1,0 +1,37 @@
+module.exports = (env) ->
+
+  hap = require 'hap-nodejs'
+  Service = hap.Service
+  Characteristic = hap.Characteristic
+
+  DimmerAccessory = require('./dimmer')(env)
+
+  class RaspBeeCTAccessory extends DimmerAccessory
+
+    _ct = null
+    #ctmin = 140
+    #ctmax = 500
+
+    constructor: (device) ->
+      super(device)
+      _ct = device._ct
+
+      @service.getCharacteristic(Characteristic.ColorTemperature)
+        .on 'get', (callback) =>
+          @handleReturnPromise(device.getCt(), callback, @getColorTemp)
+
+      @service.getCharacteristic(Characteristic.ColorTemperature)
+        .on 'set', (value, callback) =>
+          ncol=Math.round((Math.min(Math.max(((value-140)/(500-140)), 0), 1))*100)
+          if ncol is @_ct
+            callback()
+            return
+          @_ct = ncol
+          @handleVoidPromise(device.setCT(ncol), callback)
+
+      device.on 'ct', (ct) =>
+        @service.updateCharacteristic(Characteristic.ColorTemperature, @getColorTemp(ct))
+
+
+    getColorTemp: (color) =>
+      return Math.round(140 + color / 100 * (500-140))

--- a/hap.coffee
+++ b/hap.coffee
@@ -17,6 +17,8 @@ module.exports = (env) =>
   ShutterAccessory = require('./accessories/shutter')(env)
   ThermostatAccessory = require('./accessories/thermostat')(env)
 
+  RaspBeeCTAccessory = require('./accessories/raspbeect')(env)
+
   crypto = env.require 'crypto'
   path = require 'path'
 
@@ -58,9 +60,10 @@ module.exports = (env) =>
       'tradfridimmer-rgb': DimmerAccessory
       'tradfridimmer-temp': DimmerAccessory
       'raspbee-dimmer': DimmerAccessory
-      'raspbee-ct': DimmerAccessory
+      'raspbee-ct': RaspBeeCTAccessory
       'raspbee-rgb': HueLightAccessory
       'raspbee-rgbct': HueLightAccessory
+      'raspbee-group-rgbct': HueLightAccessory
     }
 
     accessories: {}

--- a/test/generic-test.coffee
+++ b/test/generic-test.coffee
@@ -1,0 +1,260 @@
+grunt = require 'grunt'
+assert = require 'assert'
+Promise = require 'bluebird'
+
+env =
+  logger:
+    debug: (stmt) ->
+      grunt.log.writeln stmt
+  require: (module) ->
+    require(module)
+
+GenericAccessory = require("../accessories/genericsensor")(env)
+hap = require 'hap-nodejs'
+Service = hap.Service
+Characteristic = hap.Characteristic
+
+class TestGeneric extends require('events').EventEmitter
+  id: "tesgeneric-id"
+  name: "testgeneric"
+  config: {}
+
+  _presence: false
+  _contact: true
+  _water: false
+  _carbon: false
+  _lux: 100.0
+  _fire: false
+
+  _battery: null
+
+  getPresence: () =>
+    return Promise.resolve(@_presence)
+
+  getContact: () =>
+    return Promise.resolve(@_contact)
+
+  getWater: () =>
+    return Promise.resolve(@_water)
+
+  getCarbon: () =>
+    return Promise.resolve(@_carbon)
+
+  getLux: () =>
+    return Promise.resolve(@_lux)
+
+  getFire: () =>
+    return Promise.resolve(@_fire)
+
+  getBattery: () =>
+    return Promise.resolve(@_battery)
+
+  fire: () =>
+    @emit 'presence', true
+    @emit 'contact', false
+    @emit 'water', true
+    @emit 'carbon', true
+    @emit 'lux', 1000
+    @emit 'fire', true
+    @emit 'battery', 10
+
+  hasAttribute: (name) =>
+    return name == 'presence' or
+      name == 'contact' or
+      name == 'water' or
+      name == 'carbon' or
+      name == 'lux' or
+      name == 'fire' or
+      name == 'battery'
+
+describe 'GenericAccessory', ->
+
+  device = null
+  accessory = null
+
+  beforeEach ->
+    device = new TestGeneric()
+    accessory = new GenericAccessory(device)
+
+  describe 'presence', ->
+
+    it "should return current value when get event is fired", ->
+      accessory.getService(Service.MotionSensor)
+        .getCharacteristic(Characteristic.MotionDetected)
+        .getValue((error, value) ->
+          assert error is null
+          assert value is false
+        )
+
+    it "should update characteristics when level changes", ->
+      valueSet = false
+      accessory.getService(Service.MotionSensor)
+        .getCharacteristic(Characteristic.MotionDetected)
+        .on 'change', (values) =>
+          assert values.newValue is true
+          valueSet = true
+      accessory.getService(Service.MotionSensor)
+        .getCharacteristic(Characteristic.MotionDetected)
+        .on 'change', (values) =>
+          assert values.oldValue is false
+          assert values.newValue is true
+          valueSet = true
+
+      device.fire()
+      assert valueSet
+
+  describe 'contact', ->
+
+    it "should return current value when get event is fired", ->
+      accessory.getService(Service.ContactSensor)
+        .getCharacteristic(Characteristic.ContactSensorState)
+        .getValue((error, value) ->
+          assert error is null
+          assert value is Characteristic.ContactSensorState.CONTACT_DETECTED
+        )
+
+    it "should update characteristics when level changes", ->
+      valueSet = false
+      accessory.getService(Service.ContactSensor)
+        .getCharacteristic(Characteristic.ContactSensorState)
+        .on 'change', (values) =>
+          assert values.oldValue is Characteristic.ContactSensorState.CONTACT_DETECTED
+          assert values.newValue is Characteristic.ContactSensorState.CONTACT_NOT_DETECTED
+          valueSet = true
+
+      device.fire()
+      assert valueSet
+
+    it "getContactSensorState should return right value", ->
+      assert accessory.getContactSensorState(true) is
+        Characteristic.ContactSensorState.CONTACT_DETECTED
+      assert accessory.getContactSensorState(false) is
+        Characteristic.ContactSensorState.CONTACT_NOT_DETECTED
+
+  describe 'water', ->
+
+    it "should return current value when get event is fired", ->
+      accessory.getService(Service.LeakSensor)
+        .getCharacteristic(Characteristic.LeakDetected)
+        .getValue((error, value) ->
+          assert error is null
+          assert value is Characteristic.LeakDetected.LEAK_NOT_DETECTED
+        )
+
+    it "should update characteristics when level changes", ->
+      valueSet = false
+      accessory.getService(Service.LeakSensor)
+        .getCharacteristic(Characteristic.LeakDetected)
+        .on 'change', (values) =>
+          assert values.newValue is Characteristic.LeakDetected.LEAK_DETECTED
+          valueSet = true
+
+      device.fire()
+      assert valueSet
+
+    it "getWaterState should return right value", ->
+      assert accessory.getWaterState(true) is
+        Characteristic.LeakDetected.LEAK_DETECTED
+      assert accessory.getWaterState(false) is
+        Characteristic.LeakDetected.LEAK_NOT_DETECTED
+
+  describe 'carbon', ->
+
+    it "should return current value when get event is fired", ->
+      accessory.getService(Service.CarbonMonoxideSensor)
+        .getCharacteristic(Characteristic.CarbonMonoxideDetected)
+        .getValue((error, value) ->
+          assert error is null
+          assert value is Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL
+        )
+
+    it "should update characteristics when level changes", ->
+      valueSet = false
+      accessory.getService(Service.CarbonMonoxideSensor)
+        .getCharacteristic(Characteristic.CarbonMonoxideDetected)
+        .on 'change', (values) =>
+          assert values.newValue is Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL
+          valueSet = true
+
+      device.fire()
+      assert valueSet
+
+    it "getCarbonState should return right value", ->
+      assert accessory.getCarbonState(true) is
+        Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL
+      assert accessory.getCarbonState(false) is
+        Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL
+
+  describe 'lux', ->
+
+    it "should return current value when get event is fired", ->
+      accessory.getService(Service.LightSensor)
+        .getCharacteristic(Characteristic.CurrentAmbientLightLevel)
+        .getValue((error, value) ->
+          assert error is null
+          assert value is 100
+        )
+
+    it "should update characteristics when level changes", ->
+      valueSet = false
+      accessory.getService(Service.LightSensor)
+        .getCharacteristic(Characteristic.CurrentAmbientLightLevel)
+        .on 'change', (values) =>
+          assert values.oldValue is 0.0001
+          assert values.newValue is 1000
+          valueSet = true
+
+      device.fire()
+      assert valueSet
+
+  describe 'fire', ->
+
+    it "should return current value when get event is fired", ->
+      accessory.getService(Service.SmokeSensor)
+        .getCharacteristic(Characteristic.SmokeDetected)
+        .getValue((error, value) ->
+          assert error is null
+          assert value is Characteristic.SmokeDetected.SMOKE_NOT_DETECTED
+        )
+
+    it "should update characteristics when level changes", ->
+      valueSet = false
+      accessory.getService(Service.SmokeSensor)
+        .getCharacteristic(Characteristic.SmokeDetected)
+        .on 'change', (values) =>
+          assert values.newValue is Characteristic.SmokeDetected.SMOKE_DETECTED
+          valueSet = true
+
+      device.fire()
+      assert valueSet
+
+    it "getSmokeState should return right value", ->
+      assert accessory.getSmokeState(true) is
+        Characteristic.SmokeDetected.SMOKE_DETECTED
+      assert accessory.getSmokeState(false) is
+        Characteristic.SmokeDetected.SMOKE_NOT_DETECTED
+
+  describe 'battery', ->
+
+    it "should return battery status when get event is fired", ->
+      check = (expected) =>
+        accessory.getService(Service.ContactSensor)
+          .getCharacteristic(Characteristic.StatusLowBattery)
+          .getValue((error, value) ->
+            assert error is null
+            assert value is expected
+          )
+      device._battery = 80
+      check(Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL)
+      device._battery = 10
+      check(Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW)
+
+    it "should set Characteristic.StatusLowBattery when lowBattery changes", ->
+      valueSet = false
+      accessory.getService(Service.ContactSensor)
+        .getCharacteristic(Characteristic.StatusLowBattery)
+        .on 'change', (values) =>
+          assert values.newValue is Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
+          valueSet = true
+      device.fire()
+      assert valueSet


### PR DESCRIPTION
i have added the multi-sensor device from raspbee to the generic device. although contact and presence are double, but now all devices with the corresponding attributes are supported , not only if the correct template is used, like the multi-sensor device. 

if this is not ok, I would create a extra accessory.